### PR TITLE
docs(readme): update contribution instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Follow these steps to set up the project locally:
  1. Fork the Repository:
     - Start by forking this repository to your GitHub account.
       ```bash
-        git clone https://github.com/KathFOSS-Club/kathfoss-web.git
+        git clone https://github.com/your-username/kathfoss-web.git
         cd kathfoss-web
       
 2. Set Up the Development Environment:
@@ -67,3 +67,6 @@ Follow these steps to set up the project locally:
 7. Open a Pull Request (PR):
    - Navigate to the original repository and click **New Pull Request**.
    - Provide clear description of your changes and link any related issues.
+
+## License 
+This project is licensed under the [MIT License](./LICENSE).


### PR DESCRIPTION
# What does this PR do?

This PR addresses an issue with the repository URL in the `README.md` file. Specifically, the `git clone` URL for cloning the repository has been updated from:

`git clone https://github.com/KathFOSS-Club/kathfoss-web.git`

to 

`git clone https://github.com/your-username/kathfoss-web.git`

Additionally, the License section of the `README.md` has been added to specify that this project is licensed under the MIT License.

## Changes Made

- [x] Updated the `git clone` command in the `README.md` to reflect the correct cloning URL format.
- [x] Added a new `License` section in the `README.md` that specifies the project is licensed under the MIT License.

## Additional Notes

This PR does not affect any functionality of the application, but updates the doc to reflect correct instructions and license information.
