### PR TITLE
chore: add .dockerignore to exclude unnecessary files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Ignore node_modules, log files and env variable files 
+node_modules/
+*.log
+*.env
+
+# Ignore dockerfile and .dockerignore
+Dockerfile
+.dockerignore
+
+# Ignore operating system-specific files
+.DS_Store
+Thumbs.db
+
+# Ignore build and output directories
+.next/
+out/
+build/
+
+# Ignore IDE and editor-specific files
+.vscode/
+.idea/
+*.swp
+
+# Ignore test coverage and temporary files
+coverage/
+*.tmp
+*.bak
+
+# Ignore other non-essential files 
+*.json


### PR DESCRIPTION
# What does this PR do?

This PR updates the `.dockerignore` file to exclude unnecessary files from the Docker build context. This ensures that files like `node_modules`, `.env`, and `.log` files are not included in the Docker image, improving build performance and preventing sensitive data from being exposed.

## Changes Made

- [x] Added common exclusion such as `node_modules/`, `*.log`, and `*.env` to `.dockerignore`.

## Additional Notes

The `.dockerignore` file helps optimize the Docker image by preventing unnecessary files from being copied into image.
