### PR TITLE
feat: Enhance HeroSection with introduction, stats, and About Us button

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -16,6 +16,7 @@ export default function Header() {
     { label: "EVENTS", href: "#events" },
     { label: "TEAM", href: "#team" },
     { label: "CONTACT", href: "#contact-us" },
+    { label: "ABOUT US", href: "#about-us" },
   ];
 
   useEffect(() => {

--- a/src/app/components/HeroSection.tsx
+++ b/src/app/components/HeroSection.tsx
@@ -66,7 +66,15 @@ export default function HeroSection() {
         }}
       >
         {/* Projects */}
-        <Box sx={{ textAlign: "center" }}>
+        <Box
+          sx={{
+            textAlign: "center",
+            backgroundColor: "rgba(255, 255, 255, 0.1)",
+            borderRadius: "8px",
+            padding: "1rem",
+            minWidth: "120px",
+          }}
+        >
           <Typography
             variant="h3"
             sx={{ fontSize: { sm: "48px", xs: "32px" }, color: "#009FE3" }}
@@ -79,7 +87,15 @@ export default function HeroSection() {
         </Box>
 
         {/* Contributors */}
-        <Box sx={{ textAlign: "center" }}>
+        <Box
+          sx={{
+            textAlign: "center",
+            backgroundColor: "rgba(255, 255, 255, 0.1)",
+            borderRadius: "8px",
+            padding: "1rem",
+            minWidth: "120px",
+          }}
+        >
           <Typography
             variant="h3"
             sx={{ fontSize: { sm: "48px", xs: "32px" }, color: "#009FE3" }}
@@ -92,7 +108,15 @@ export default function HeroSection() {
         </Box>
 
         {/* Events Organized */}
-        <Box sx={{ textAlign: "center" }}>
+        <Box
+          sx={{
+            textAlign: "center",
+            backgroundColor: "rgba(255, 255, 255, 0.1)",
+            borderRadius: "8px",
+            padding: "1rem",
+            minWidth: "120px",
+          }}
+        >
           <Typography
             variant="h3"
             sx={{ fontSize: { sm: "48px", xs: "32px" }, color: "#009FE3" }}
@@ -105,7 +129,15 @@ export default function HeroSection() {
         </Box>
 
         {/* Years Active */}
-        <Box sx={{ textAlign: "center" }}>
+        <Box
+          sx={{
+            textAlign: "center",
+            backgroundColor: "rgba(255, 255, 255, 0.1)",
+            borderRadius: "8px",
+            padding: "1rem",
+            minWidth: "120px",
+          }}
+        >
           <Typography
             variant="h3"
             sx={{ fontSize: { sm: "48px", xs: "32px" }, color: "#009FE3" }}
@@ -118,7 +150,15 @@ export default function HeroSection() {
         </Box>
 
         {/* Community Members */}
-        <Box sx={{ textAlign: "center" }}>
+        <Box
+          sx={{
+            textAlign: "center",
+            backgroundColor: "rgba(255, 255, 255, 0.1)",
+            borderRadius: "8px",
+            padding: "1rem",
+            minWidth: "120px",
+          }}
+        >
           <Typography
             variant="h3"
             sx={{ fontSize: { sm: "48px", xs: "32px" }, color: "#009FE3" }}

--- a/src/app/components/HeroSection.tsx
+++ b/src/app/components/HeroSection.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, Button } from "@mui/material";
 import Timer from "./ui/Timer/Timer";
 
 export default function HeroSection() {
@@ -7,8 +7,10 @@ export default function HeroSection() {
       sx={{
         textAlign: "center",
         my: "8rem",
+        padding: { xs: "1rem", sm: "2rem" },
       }}
     >
+      {/* Main Heading */}
       <Typography
         variant="h1"
         sx={{
@@ -20,16 +22,116 @@ export default function HeroSection() {
       >
         KATHFOSS
       </Typography>
+
+      {/* Tagline */}
       <Typography
         sx={{
           fontSize: { sm: "18px !important", xs: "10px" },
           fontWeight: "bold",
           letterSpacing: { sm: "6px", xs: "5px" },
           color: "#898686",
+          marginTop: "1rem",
         }}
       >
         “Code, Collaborate, Contribute”
       </Typography>
+
+      {/* About Us Section */}
+      <Box id="about-us" sx={{ marginTop: "4rem" }}>
+        <Typography
+          variant="h6"
+          sx={{
+            fontSize: { sm: "24px", xs: "16px" },
+            fontWeight: "normal",
+            color: "#fff",
+            marginTop: "2rem",
+            maxWidth: "800px",
+            margin: "2rem auto",
+            lineHeight: "1.6",
+          }}
+        >
+          A community for open-source enthusiasts fostering collaboration and
+          contribution.
+        </Typography>
+      </Box>
+
+      {/* Statistics Section */}
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          justifyContent: "center",
+          gap: { xs: "1rem", sm: "2rem" },
+          marginTop: "4rem",
+        }}
+      >
+        {/* Projects */}
+        <Box sx={{ textAlign: "center" }}>
+          <Typography
+            variant="h3"
+            sx={{ fontSize: { sm: "48px", xs: "32px" }, color: "#009FE3" }}
+          >
+            2
+          </Typography>
+          <Typography variant="h6" sx={{ color: "#fff" }}>
+            Projects
+          </Typography>
+        </Box>
+
+        {/* Contributors */}
+        <Box sx={{ textAlign: "center" }}>
+          <Typography
+            variant="h3"
+            sx={{ fontSize: { sm: "48px", xs: "32px" }, color: "#009FE3" }}
+          >
+            13
+          </Typography>
+          <Typography variant="h6" sx={{ color: "#fff" }}>
+            Contributors
+          </Typography>
+        </Box>
+
+        {/* Events Organized */}
+        <Box sx={{ textAlign: "center" }}>
+          <Typography
+            variant="h3"
+            sx={{ fontSize: { sm: "48px", xs: "32px" }, color: "#009FE3" }}
+          >
+            50+
+          </Typography>
+          <Typography variant="h6" sx={{ color: "#fff" }}>
+            Events Organized
+          </Typography>
+        </Box>
+
+        {/* Years Active */}
+        <Box sx={{ textAlign: "center" }}>
+          <Typography
+            variant="h3"
+            sx={{ fontSize: { sm: "48px", xs: "32px" }, color: "#009FE3" }}
+          >
+            15+
+          </Typography>
+          <Typography variant="h6" sx={{ color: "#fff" }}>
+            Years Active
+          </Typography>
+        </Box>
+
+        {/* Community Members */}
+        <Box sx={{ textAlign: "center" }}>
+          <Typography
+            variant="h3"
+            sx={{ fontSize: { sm: "48px", xs: "32px" }, color: "#009FE3" }}
+          >
+            500+
+          </Typography>
+          <Typography variant="h6" sx={{ color: "#fff" }}>
+            Community Members
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Timer Component */}
       <Timer />
     </Box>
   );


### PR DESCRIPTION
This PR enhances the `HeroSection` component by adding:
1. A **1-2 line introduction** about KATHFOSS.
2. A **statistics section** displaying key metrics (projects, contributors, events, years active, community members).
3. An **About Us button** in the navigation bar that scrolls to the About Us section.

## Changes
- Added an introduction text in the `HeroSection`.
- Added a statistics section with key metrics.
- Added an "About Us" button to the navigation bar (`Header.tsx`).

## Testing
- Verified that the About Us button scrolls to the correct section.

## Screenshot of Updated UI
![HeroSection Update](https://github.com/user-attachments/assets/4e745824-63f3-445c-8e61-6fbbc79029cb)

Fixes #49

## Screenshot of Updated UI V2: Box design similar to Timer Component
![Update UI V2](https://github.com/user-attachments/assets/388cc9dd-89a3-459c-a634-b374d22aecf9)
